### PR TITLE
Fix newline bug

### DIFF
--- a/de_novo_finder_3.py
+++ b/de_novo_finder_3.py
@@ -1348,7 +1348,7 @@ def main(vcffile, Fam, args):
 
     # Move line by line through the VCF
     for line in vcffile:
-        line = line.split('\t')
+        line = line.strip('\n').split('\t')
 
         chrom_under_study = line[0]
         if chrom_under_study.startswith('chr'):


### PR DESCRIPTION
Found a bug related to trailing newlines while implementing this in Hail.

You could get PL arrays like this:
```
['1956', '652', '0\n']
```

When checking if `pl[2] == '0'`, it would return `False` erroneously.